### PR TITLE
SCSS: add fallback font-family `monospace`  for <code> tag

### DIFF
--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -94,7 +94,7 @@ blockquote {
 }
 
 code {
-  font-family: 'Lucida Sans', Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+  font-family: 'Lucida Sans', Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
   color:#efefef;
   font-size:13px;
   margin: 0 4px;


### PR DESCRIPTION
* fix issue pages-themes/midnight#2