### PR TITLE
Update jekyll-theme-midnight.scss

### DIFF
--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -94,7 +94,7 @@ blockquote {
 }
 
 code {
-  font-family: 'Lucida Sans', Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
+  font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
   color:#efefef;
   font-size:13px;
   margin: 0 4px;


### PR DESCRIPTION
Lucida Sans font is not a monospaced font and should not be used for &lt;code&gt; blocks. On Windows system font Lucida Sans Regular is evaluated for code blocks where proportional font looks ugly.