### PR TITLE
Changed to Matt Graham's new Twitter handle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,7 +37,7 @@
           <p>{{ site.description | default: site.github.project_tagline }}</p>
           <hr>
           <span class="credits left">Project maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
-          <span class="credits right">Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/michigangraham">mattgraham</a></span>
+          <span class="credits right">Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/mattgraham">mattgraham</a></span>
         </div>
 
         {{ content }}


### PR DESCRIPTION
If one visits the old Twitter handle, they will see that this user has no tweets and the bio says:

> This account has been moved to `@mattgraham` please follow over there.

Therefore the link gets updated to the new handle.