### PR TITLE
Setup theme-color in head tags.

### DIFF
--- a/_includes/theme_color_meta_headers.html
+++ b/_includes/theme_color_meta_headers.html
@@ -1,0 +1,5 @@
+<!-- start theme color meta headers -->
+<meta name="theme-color" content="#353535">
+<meta name="msapplication-navbutton-color" content="#353535">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<!-- end theme color meta headers -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,10 @@
     <link rel="stylesheet" href="{{ '/assets/css/ie.css' | relative_url }}">
     <![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <!-- Setup theme-color. -->
+    <meta name="theme-color" content="#353535">
+    <meta name="msapplication-navbutton-color" content="#353535">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
   </head>
   <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,9 +16,7 @@
     <![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <!-- Setup theme-color. -->
-    <meta name="theme-color" content="#353535">
-    <meta name="msapplication-navbutton-color" content="#353535">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    {% include theme_color_meta_headers.html %}
 
   </head>
   <body>


### PR DESCRIPTION
This is picked up by browsers (mostly mobile browsers)
and used e.g. to style the browser header.
It is mostly of use for dark themes such as midnight.

closes #29