### PR TITLE
Prefer site.tagline for site subtitle if defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Midnight will respect the following variables, if set in your site's `_config.ym
 
 ```yml
 title: [The title of your site]
-description: [A short description of your site's purpose]
+tagline: [A very short description of your site's purpose, used as subtitle]
+description: [A short description of your site's purpose (e.g. for search engines)]
 ```
 
 Additionally, you may choose to set the following optional variables:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
       <section>
         <div id="title">
           <h1>{{ site.title | default: site.github.repository_name }}</h1>
-          <p>{{ site.description | default: site.github.project_tagline }}</p>
+          <p>{{ site.tagline | default: site.description | default: site.github.project_tagline }}</p>
           <hr>
           <span class="credits left">Project maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
           <span class="credits right">Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/mattgraham">mattgraham</a></span>


### PR DESCRIPTION
Search engines expect slightly more context than the page subtitle provides.
Following the definition in jekyll-seo-tag, the tagline
is used as subtitle if set, while the description is exposed in the meta tag.