### PR TITLE
Add Google Analytics to head-custom.html to allow easier customization of the GA code

### DIFF
--- a/_includes/head-custom-google-analytics.html
+++ b/_includes/head-custom-google-analytics.html
@@ -1,0 +1,10 @@
+{% if site.google_analytics %}
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', '{{ site.google_analytics }}', 'auto');
+    ga('send', 'pageview');
+  </script>
+{% endif %}

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,9 +1,12 @@
-<!-- start custom head snippets -->
+<!-- start custom head snippets, customize with your own _includes/head-custom.html file -->
 
-<!-- Setup theme-color. -->
+<!-- Setup theme-color -->
 {% include head-custom-theme-colors.html %}
 
-<!-- You can set your favicon here. -->
+<!-- Setup Google Analytics -->
+{% include head-custom-google-analytics.html %}
+
+<!-- You can set your favicon here -->
 <!-- link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}" -->
 
 <!-- end custom head snippets -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,16 +47,5 @@
       </section>
 
     </div>
-
-    {% if site.google_analytics %}
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        ga('create', '{{ site.google_analytics }}', 'auto');
-        ga('send', 'pageview');
-      </script>
-    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
Users can now simply override the includes instead of the entire default layout.