### PR TITLE
Change background gradient in jekyll-theme-midnight.scss to background-image property

### DIFF
--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -8,9 +8,9 @@ body {
   font:14px/1.5 "OpenSansRegular", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color:#f0e7d5;
   font-weight: normal;
-  background: #252525;
+  background: #2a2a29;
   background-attachment: fixed !important;
-  background: linear-gradient(#2a2a29, #1c1c1c);
+  background-image: linear-gradient(#2a2a29, #1c1c1c);
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
When using a mouse wheel or two-finger scrolling to scroll up past the top of a website, you can see the background of a site past the main window. Usually you just see the `background` color from the page body there. In the current version that overlap is white because there are two `background` properties specified in `_sass/jekyll-theme-midnight.scss`. Currently, the last `background` property with the linear gradient overrides the first. Switching that one to `background-image` as described [here](https://css-tricks.com/css3-gradients/) makes it so that the first `background` property still applies to that overlap space and provides a bit cleaner transition, while the linear gradient is preserved.

Before and after screenshots in Chrome are attached:

<img width="843" alt="chrome_screenshot_after" src="https://user-images.githubusercontent.com/48640658/129985027-0df38f16-a198-4adb-9f74-5305e932b990.png">
<img width="990" alt="chrome_screenshot_before" src="https://user-images.githubusercontent.com/48640658/129985034-8d22519c-1681-4663-9b11-b1547097cfa6.png">
