### PR TITLE
Add `page.lang` page parameter

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ site.lang | default: "en-US" }}">
+<html lang="{{ page.lang | default: site.lang | default: "en-US" }}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Some of the pages on my website will be available in multiple languages, and I would like to have an option to allow users to specify the language (`<html lang="en-US">`) for specific pages. 

After this PR merge, users can specify the page language by adding the following content at the top of the page:

```YAML
---
lang: de-DE
---
```

